### PR TITLE
Fix passing of a hash as kwargs (get ready for ruby 3)

### DIFF
--- a/lib/ponto.rb
+++ b/lib/ponto.rb
@@ -27,7 +27,7 @@ module Ponto
   class << self
     def client
       options = configuration.to_h.delete_if { |_, v| v.nil? }
-      @client ||= Ponto::Client.new(options)
+      @client ||= Ponto::Client.new(**options)
     end
 
     def configure


### PR DESCRIPTION
This is a fix for the infamous warning:

```
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
```

when using ruby 2.7

(https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)